### PR TITLE
Expansion of initial node implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
-/pom.xml
-/target
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/lib/
+/classes/
+/target/
+/checkouts/
+.lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures
+
+.nrepl-port
+.nrepl-history

--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ See [abio](https://github.com/abiocljs/abio#usage).
 
 Copyright © 2017 abiocljs and Contributors
 
-Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.
+Distributed under the Eclipse Public License either version 1.0 or (at your
+option) any later version.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # abio-node
 
+TODO: Should we combine synchronous and asynchronous read/write/stream
+functions? Currently we have two records for each type, such as `BufferedReader`
+and `AsynchronousBufferedReader`, along with `reader`/`async-reader` functions
+in abio core.
+
+While this makes it really clear how to get a sync/async thing, it also
+duplicates a lot of code. Currently, the `BufferedReader` and
+`AsynchronousBufferedReader` both define the single and double arity form of
+each of the protocols they're extending, except the `BR` throws on double arity
+-- because the second argument is a callback -- and `ABR` throws on single
+arity, since it's lacking the callback it needs.
+
+Both records take the same three arguments, and we don't do any branch logic
+based on whether it's a `BR` or `ABR` record, so I don't think there's much
+point in having both.
+
 ## Usage
 
 See [abio](https://github.com/abiocljs/abio#usage).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [abio usage](https://github.com/abiocljs/abio#usage) and [examples/walkthrou
 5. Create Stream implementations.
 6. Bind `*in*` with `abio.core/set-bindings!`
 7. Get `abio.io/slurp` working with the node bindings.
+8. How best can we signal the arities of the callback functions for each protocol method?
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
 # abio-node
 
-TODO: Should we combine synchronous and asynchronous read/write/stream
-functions? Currently we have two records for each type, such as `BufferedReader`
-and `AsynchronousBufferedReader`, along with `reader`/`async-reader` functions
-in abio core.
-
-While this makes it really clear how to get a sync/async thing, it also
-duplicates a lot of code. Currently, the `BufferedReader` and
-`AsynchronousBufferedReader` both define the single and double arity form of
-each of the protocols they're extending, except the `BR` throws on double arity
--- because the second argument is a callback -- and `ABR` throws on single
-arity, since it's lacking the callback it needs.
-
-Both records take the same three arguments, and we don't do any branch logic
-based on whether it's a `BR` or `ABR` record, so I don't think there's much
-point in having both.
+Node bindings for the abio cljs library.
 
 ## Usage
 
-See [abio](https://github.com/abiocljs/abio#usage).
+See [abio usage](https://github.com/abiocljs/abio#usage) and [examples/walkthrough.cljs](examples/walkthrough.cljs)
+
+## Todo
+1. Should we switch to `fs.read`/`fs.readSync` instead of `fs.readFile`/`fs.readFileSync`, and
+   emulate the buffered reads in `clojure.java.io`/planck/etc? What're the pros/cons?
+2. Should we support buffered and unbuffered readers/writers? I think an unbuffered version of
+   `fs.{read,write}` is simply a call to those methods with a length of 1.
+3. We don't currently leverage File records; should we?
+4. What abstractions might a File record assume, over, say a Resource record or some other, more
+   general record type?
+5. Create Stream implementations.
+6. Bind `*in*` with `abio.core/set-bindings!`
+7. Get `abio.io/slurp` working with the node bindings.
 
 ## License
 

--- a/examples/walkthrough.cljs
+++ b/examples/walkthrough.cljs
@@ -1,0 +1,77 @@
+(ns abio.node.walkthrough
+  (:require [abio.io :as io]
+            abio.node
+            abio.core
+            [clojure.pprint :as pp]
+            [clojure.string :as string]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Set up the host specific bindings.
+;;
+;; This is the first function that's called, setting up the host specific I/O
+;; machinery used by the higher level functions.
+(abio.core/set-bindings! (abio.node/bindings))
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; General FS bindings
+;;
+;; These are things that don't, necessarily, warrant opening up some Reader or
+;; Writer, currently limited to listing files, returning the host path
+;; separator, and checking whether some path is a directory
+
+;; In both of these examples we're calling the methods defined in `abio.io`
+;; against the `abio.core` dynamic var `*io-bindings*`, which we'd defined in
+;; our call to `set-bindings!`. Whatever record is stored in `*io-bindings*`
+;; needs to extend the `abio.io/IBindings` protocol.
+
+;; Synchronous directory listing
+(defn sync-ls
+  [path]
+  (if (not (io/-directory? abio.core/*io-bindings* path))
+    (println "Path needs to be a directory, but you gave me the following: " path)
+    (do (println "Synchronously listing files in " path)
+        (io/-list-files abio.core/*io-bindings* path))))
+
+;; Asynchronous directory listing
+(defn async-ls-cb
+  [err files]
+  (println "Here's the files we got back from the asynchronous -list-files call.")
+  (pp/pprint files))
+
+(defn async-ls
+  [path]
+  (if (not (io/-directory? abio.core/*io-bindings* path))
+    (println "Path needs to be a directory, but you gave me the following: " path)
+    (do
+      (println "Asynchronously listing files in " path)
+      (io/-list-files abio.core/*io-bindings* path async-ls-cb))))
+
+;;;;;;;;;;;;;;;;
+;; Reading Files
+;;
+;; We currently split reading and writing into two different methods on the
+;; `IBindings` protocol -- `-file-reader-open` and `-file-writer-open` -- though
+;; that may change in the future. Realistically, you could have a single record,
+;; say `BufferedFile`, and implement `IReader` and `IAbioWriter` for it, which
+;; would allow both reading and writing to the same path via a single var.
+
+;; Let's read some data; we start by defining our reader, which we'll pass to
+;; both of the following functions.
+(def rdr (abio.io/reader "project.clj" :encoding "utf8"))
+
+;; Here's a sync read
+(defn sync-read
+  [reader]
+  (if (io/-directory? abio.core/*io-bindings* (:path reader))
+    (println "You asked me to read a directory, but I only work on files.")
+    (do (println "Synchronously reading the contents of" (:path reader) "\n")
+        (abio.io/-read reader))))
+
+;; Here's an async read
+(defn async-read
+  [reader]
+  (if (io/-directory? abio.core/*io-bindings* (:path reader))
+    (println "You asked me to read a directory, but I only work on files.")
+    (abio.io/-read rdr (fn [err data]
+                         (println "Asynchronously read the contents of" (:path reader) "\n")
+                         (println data)))))

--- a/examples/walkthrough.cljs
+++ b/examples/walkthrough.cljs
@@ -1,16 +1,14 @@
 (ns abio.node.walkthrough
   (:require [abio.io :as io]
-            abio.node
-            abio.core
-            [clojure.pprint :as pp]
-            [clojure.string :as string]))
+            [abio.node :as node]
+            [abio.core :refer [*io-bindings*]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Set up the host specific bindings.
 ;;
 ;; This is the first function that's called, setting up the host specific I/O
 ;; machinery used by the higher level functions.
-(abio.core/set-bindings! (abio.node/bindings))
+(abio.core/set-bindings! (node/bindings))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; General FS bindings
@@ -27,10 +25,10 @@
 ;; Synchronous directory listing
 (defn sync-ls
   [path]
-  (if (not (io/-directory? abio.core/*io-bindings* path))
+  (if (not (io/-directory? *io-bindings* path))
     (println "Path needs to be a directory, but you gave me the following: " path)
     (do (println "Synchronously listing files in " path)
-        (io/-list-files abio.core/*io-bindings* path))))
+        (io/-list-files *io-bindings* path))))
 
 ;; Asynchronous directory listing
 (defn async-ls-cb
@@ -40,11 +38,11 @@
 
 (defn async-ls
   [path]
-  (if (not (io/-directory? abio.core/*io-bindings* path))
+  (if (not (io/-directory? *io-bindings* path))
     (println "Path needs to be a directory, but you gave me the following: " path)
     (do
       (println "Asynchronously listing files in " path)
-      (io/-list-files abio.core/*io-bindings* path async-ls-cb))))
+      (io/-list-files *io-bindings* path async-ls-cb))))
 
 ;;;;;;;;;;;;;;;;
 ;; Reading Files
@@ -62,7 +60,7 @@
 ;; Here's a sync read
 (defn sync-read
   [reader]
-  (if (io/-directory? abio.core/*io-bindings* (:path reader))
+  (if (io/-directory? *io-bindings* (:path reader))
     (println "You asked me to read a directory, but I only work on files.")
     (do (println "Synchronously reading the contents of" (:path reader) "\n")
         (abio.io/-read reader))))
@@ -76,7 +74,7 @@
 
 (defn async-read
   [reader]
-  (if (io/-directory? abio.core/*io-bindings* (:path reader))
+  (if (io/-directory? *io-bindings* (:path reader))
     (println "You asked me to read a directory, but I only work on files.")
     (do
       (println "Asynchronously reading the contents of" (:path reader) "\n")

--- a/examples/walkthrough.cljs
+++ b/examples/walkthrough.cljs
@@ -33,8 +33,8 @@
 ;; Asynchronous directory listing
 (defn async-ls-cb
   [err files]
-  (println "\nHere's the files we got back from the asynchronous -list-files call.")
-  (pp/pprint files))
+  (println "\nHere's the list of files we got back from the asynchronous -list-files call.")
+  (println files))
 
 (defn async-ls
   [path]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject abio-node "0.1.0"
   :dependencies [[org.abiocljs/abio "0.1.0"]
                  [org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.293"]])
+                 [org.clojure/clojurescript "1.9.293"]
+                 [andare "0.6.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject abio-node "0.1.0"
   :dependencies [[org.abiocljs/abio "0.1.0"]
                  [org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.293"]
-                 [andare "0.6.0"]])
+                 [org.clojure/clojurescript "1.9.293"]])

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -2,7 +2,12 @@
   (:require
     [abio.io :as io]
     [clojure.string :as string]
-    [clojure.core.async :as async]))
+    [cljs.core.async :as async])
+  (:require-macros
+   [cljs.core.async.macros :refer [go go-loop]]))
+
+;; (require '[abio.io :as io] '[clojure.string :as string] '[cljs.core.async :as async])
+;; (require-macros '[cljs.core.async.macros :refer [go go-loop]])
 
 (defrecord BufferedReader [raw-read raw-close buffer pos]
   abio.io/IReader
@@ -40,11 +45,53 @@
   (-close [_]
     (raw-close)))
 
-(defrecord Bindings [fs]
+;; How would this be used?
+;; You call -read and it gives you a channel? How do you read multiple items? I guess I should just write
+;; I might be wrong in just trying to wrap a BufferedReader. I think also I need to wrap it all inside a go loop
+(defrecord AsyncBufferedReader [buffered-reader]
+  abio.io/IAsyncReader
+  (-read [_]
+    (let [chan (async/chan)]
+      (go
+        (loop [data (-read buffered-reader)]
+          (if data
+            (do
+              (async/>! chan data)
+              (recur (-read buffered-reader)))
+            (async/close! chan ))))
+      chan))
+  abio.io/IAsyncBufferedReader
+  (-read-line [_] ;; Will this create a channel every time? I think it will....
+    (let [chan (async/chan)]
+      (go
+        (loop [line (-read-line buffered-reader)]
+          (if line
+            (do
+              (async/>! chan line)
+              (recur (-read-line buffered-reader)))
+            (async/close! chan))))
+      chan))
+  abio.io/IClosable
+  (-close [_]
+    (go (-close buffered-reader))))
+
+;; TODO: add some js->clj to this? More broadly, how/should we offer up cljs data?
+(defrecord Bindings [fs sep]
   abio.io/IBindings
+  (-path-sep [this] sep)
   (-directory? [this f]
     (.. fs (lstatSync f) (isDirectory)))
-  (-list-files [this d])
+  (-list-files [this d]
+    (.. fs (readdirSync d)))
+  (-async-list-files [this d]
+    (let [chan (async/chan)
+          cb (fn [err contents]
+               (if err
+                 (async/>! chan err)
+                 (async/>! chan contents))
+               (async/close! chan))]
+      (go
+        (.. fs (readdir d cb))))) ;; XXX I have no idea if this works yet
   (-delete-file [this f])
   (-file-reader-open [this path encoding]
     (let [fd (.openSync fs path "r")
@@ -52,14 +99,24 @@
       (.pause read-stream)
       (.read read-stream)                                   ; Hack to get buffer primed
       (->BufferedReader #(.read read-stream) #(.close fs fd) (atom nil) (atom 0))))
-  (-file-async-reader-open [this path encoding]
-    (let [chan (async/promise-chan)
-          cb (fn [& args] (async/put! chan (vec args)))]
-      (.readFile fs path encoding cb)
-      chan))
+  (-async-file-reader-open [this path encoding]
+    (->AsyncBufferedReader (-file-reader-open this path encoding))
+    ;; (let [chan (async/promise-chan)
+    ;;       cb (fn [& args] (async/put! chan (vec args)))]
+    ;;   (.readFile fs path encoding cb)
+    ;;   chan)
+    )
+  ;; (-async-file-writer-write [this path data & opts]
+  ;;   (let [chan (async/promise-chan)
+  ;;         cb #(async/put! chan (vec %))]
+  ;;     (.writeFile fs path data (clj->js (apply hash-map opts) cb))))
   (-file-reader-read [this reader])
-  (-file-reader-close [this reader]))
+  (-file-reader-close [this reader])
+
+  )
 
 (defn bindings
   []
-  (->Bindings (js/require "fs")))
+  (->Bindings (js/require "fs")
+              (.-sep (js/require "path"))
+              ))

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -77,5 +77,4 @@
 (defn bindings
   []
   (->Bindings (js/require "fs")
-              (.-sep (js/require "path"))
-              ))
+              (.-sep (js/require "path"))))

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -90,15 +90,7 @@
     ;; In fact, is it possible to have an unbuffered write stream? maybe skip that for the time being?
     (->BufferedWriter path encoding {:flags flags} fs))
   (-async-file-writer-open [this path encoding options]
-    (->AsyncBufferedWriter (io/-file-writer-open this path encoding options)))
-
-  ;; (-async-file-writer-write [this path data & opts]
-  ;;   (let [chan (async/promise-chan)
-  ;;         cb #(async/put! chan (vec %))]
-  ;;     (.writeFile fs path data (clj->js (apply hash-map opts) cb))))
-  (-file-reader-read [this reader]) ; pretty sure this isn't necessary, as IClosable, etc covers how to read
-  (-file-reader-close [this reader])
-  )
+    (->AsyncBufferedWriter (io/-file-writer-open this path encoding options))))
 
 (defn bindings
   []

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -79,43 +79,27 @@
   (-close [_]
     (go (io/-close buffered-reader))))
 
-;; -write should write data immediately
-;; -buffered-write should buffer up a bunch of data, flush, buffer, repeat
-;; -flush should write whatever buffered data there is currently
 (defrecord BufferedWriter [raw-write raw-close]
-  ;; abio.io/IWriter
-  ;; TODO: Does it make sense to have an unbuffered write? Do we care?
-  ;; (-write [this]
-  ;;   (if-some [buffered @buffer]
-  ;;     (do
-  ;;       (reset! buffer nil)
-  ;;       (raw-write buffered))))
-  ;; (-write [_ output]
-  ;;   (raw-write output))
-  ;; (-write [_ output channel]
-  ;;   (go (async/>! channel (raw-write output))))
-
-  abio.io/IBufferedWriter
-  (-buffered-write [_ output]
+  abio.io/IAbioWriter
+  (-write [_ output]
     (raw-write output))
-  (-buffered-write [_ output channel]
-    (throw (ex-info "No double arity -buffered-write for BufferedWriter" {})))
+  (-write [_ output channel]
+    (throw (ex-info "No double arity -write for BufferedWriter" {})))
 
   abio.io/IClosable
   (-close [_]
     (raw-close)))
 
 (defrecord AsyncBufferedWriter [buffered-writer]
-  abio.io/IBufferedWriter
-  (-buffered-write [_ output]
-    (throw (ex-info "No single arity -buffered-write for AsyncBufferedWriter" {})))
-  (-buffered-write [_ output channel]
-    (go (async/>! channel (io/-buffered-write buffered-writer output))))
+  abio.io/IAbioWriter
+  (-write [_ output]
+    (throw (ex-info "No single arity -write for AsyncBufferedWriter" {})))
+  (-write [_ output channel]
+    (go (async/>! channel (io/-write buffered-writer output))))
 
   abio.io/IClosable
   (-close [_]
-    (io/-close buffered-writer))
-  )
+    (io/-close buffered-writer)))
 
 ;; TODO: add some js->clj to this? More broadly, how/should we offer up cljs data?
 (defrecord Bindings [fs sep]

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -49,9 +49,9 @@
   (-close [_]
     (raw-close)))
 
-;; How would this be used?
-;; You call -read and it gives you a channel? How do you read multiple items? I guess I should just write
 ;; I might be wrong in just trying to wrap a BufferedReader. I think also I need to wrap it all inside a go loop
+;; TODO I could also potentially just make the 2-arity function in BufferedReader async
+;;      This might simplify the code some
 (defrecord AsyncBufferedReader [buffered-reader]
   abio.io/IReader
   (-read [_] (throw (ex-info "No single arity -read for AsyncBufferedReader" {})))
@@ -160,7 +160,7 @@
   ;;   (let [chan (async/promise-chan)
   ;;         cb #(async/put! chan (vec %))]
   ;;     (.writeFile fs path data (clj->js (apply hash-map opts) cb))))
-  (-file-reader-read [this reader])
+  (-file-reader-read [this reader]) ; pretty sure this isn't necessary, as IClosable, etc covers how to read
   (-file-reader-close [this reader])
   )
 

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -58,8 +58,8 @@
     (.. fs (lstatSync f) (isDirectory)))
   (-list-files [this d]
     (.. fs (readdirSync d)))
-  (-async-list-files [this d cb]
-    (.. fs (readdir d cb))) ;; XXX I have no idea if this works yet
+  (-list-files [this d cb]
+    (.. fs (readdir d cb)))
   (-delete-file [this f])
 
 

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -34,17 +34,6 @@
             (recur (io/-read buffered-reader)))
           (async/close! chan)))))
 
-  abio.io/IBufferedReader
-  (-read-line [_] (throw (ex-info "No single arity -read-line for AsyncBufferedReader" {})))
-  (-read-line [_ chan]
-    (go
-      (loop [line (io/-read-line buffered-reader)]
-        (if line
-          (do
-            (async/>! chan line)
-            (recur (io/-read-line buffered-reader)))
-          (async/close! chan)))))
-
   abio.io/IClosable
   (-close [_]
     (go (io/-close buffered-reader))))

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -10,47 +10,29 @@
   abio.io/IReader
   (-read [_]
     (.readFileSync fs path (clj->js opts)))
-  (-read [_ _] (throw (ex-info "No double arity -read for a synchronous Node BufferedReader" {})))
+  ;; TODO: `cb` has to be 2-arity, first param is errors and second is data
+  (-read [_ cb]
+    ;; TODO if this is a fd it won't get closed automatically; eventually that needs to be checked for.
+    (.readFile fs path (clj->js opts) cb))
 
   abio.io/IClosable
   ;; Even though there's nothing to close here, we keep it to preserve the use of `with-open`
   (-close [_] nil))
 
-;; TODO I could also potentially just make the 2-arity function in BufferedReader async
-;;      This might simplify the code some
-(defrecord AsyncBufferedReader [path opts fs] ; `opts` needs :encoding and optionally :flag TODO how do I want to enforce that?
-  abio.io/IReader
-  (-read [_] (throw (ex-info "No single arity -read for AsyncBufferedReader" {})))
-  (-read [_ cb] ; `cb` has to be 2-arity, first param is errors and second is data
-    (.readFile fs path (clj->js opts) cb)) ; TODO if this is a fd it won't get closed automatically; eventually that needs to be checked for.
-
-  abio.io/IClosable
-  (-close [_]
-    ;; TODO: should these `-close` functions return true or nil?
-    true))
-
 (defrecord BufferedWriter [path opts fs]
   abio.io/IAbioWriter
   (-write [_ output]
     (.writeFileSync fs path output (clj->js opts)))
-  (-write [_ output _]
-    (throw (ex-info "No double arity -write for BufferedWriter" {})))
+  ;; XXX `cb` takes one arg, `err`, but otherwise execution signals completion of the write.`
+  ;; TODO: is there a good way to signal that, or do we have to just assume the
+  ;; consumer of the node library know it?
+  (-write [_ output cb]
+    (.writeFile fs path output (clj->js opts) cb))
 
   abio.io/IClosable
   (-close [_]
     nil))
 
-(defrecord AsyncBufferedWriter [path opts fs] ; TODO can the `flags` actually be kept as a map `opts`?
-  abio.io/IAbioWriter
-  (-write [_ output]
-    (throw (ex-info "No single arity -write for AsyncBufferedWriter" {})))
-  (-write [_ output cb] ; XXX `cb` takes one arg, `err`, but otherwise execution signals completion of the write.`
-    (.writeFile fs path output (clj->js opts) cb))
-
-  abio.io/IClosable
-  (-close [_] true))
-
-;; TODO: add some js->clj to this? More broadly, how/should we offer up cljs data?
 (defrecord Bindings [fs sep]
   abio.io/IBindings
   (-path-sep [this] sep)
@@ -62,17 +44,12 @@
     (.. fs (readdir d cb)))
   (-delete-file [this f])
 
-
   (-file-reader-open [this path opts]
     (->BufferedReader path opts fs))
-  (-async-file-reader-open [this path opts]
-    (->AsyncBufferedReader path opts fs))
 
   ;; Default to non-destructive write
   (-file-writer-open [this path opts]
-    (->BufferedWriter path (merge {:flag "a"} opts) fs))
-  (-async-file-writer-open [this path opts]
-    (->AsyncBufferedWriter path (merge {:flag "a"} opts) fs)))
+    (->BufferedWriter path (merge {:flag "a"} opts) fs)))
 
 (defn bindings
   []

--- a/src/abio/node/io.cljs
+++ b/src/abio/node/io.cljs
@@ -3,14 +3,10 @@
    [abio.io :as io]
    [clojure.string :as string]))
 
-;; (require '[abio.io :as io] '[clojure.string :as string] '[cljs.core.async :as async])
-;; (require-macros '[cljs.core.async.macros :refer [go go-loop]])
-
 (defrecord BufferedReader [path opts fs] ; `opts` should contain :encoding and optionally :flag
   abio.io/IReader
   (-read [_]
     (.readFileSync fs path (clj->js opts)))
-  ;; TODO: `cb` has to be 2-arity, first param is errors and second is data
   (-read [_ cb]
     ;; TODO if this is a fd it won't get closed automatically; eventually that needs to be checked for.
     (.readFile fs path (clj->js opts) cb))
@@ -23,9 +19,6 @@
   abio.io/IAbioWriter
   (-write [_ output]
     (.writeFileSync fs path output (clj->js opts)))
-  ;; XXX `cb` takes one arg, `err`, but otherwise execution signals completion of the write.`
-  ;; TODO: is there a good way to signal that, or do we have to just assume the
-  ;; consumer of the node library know it?
   (-write [_ output cb]
     (.writeFile fs path output (clj->js opts) cb))
 


### PR DESCRIPTION
This PR does two major things: 1) add async support to the node implementation of the `abio.io` reader/writer protocols, and 2) rely heavily on Node's `fs` library for working with files, instead of implementing buffering and streams, etc. by hand.

I moved away from Streams as the underlying BufferedReader/Writer implementation because Node doesn't have a concept of synchronous Streams, instead using asynchronous events and registered callbacks. Since we can't just create a Stream and immediately begin working with it without putting in odd hacks, I decided to skip them for the time being.

Mike, I've added you as a reviewer because I figure it's a good idea to have others review our code, but let me know if you're not interested -- I believe you've implemented most of this in planck already -- and I can just merge the branch without review.